### PR TITLE
Enable simple SSL connection

### DIFF
--- a/lib/paho_mqtt/client.rb
+++ b/lib/paho_mqtt/client.rb
@@ -70,6 +70,10 @@ module PahoMqtt
         self.send("#{k}=", v)
       end
 
+      if @ssl
+        @ssl_context = OpenSSL::SSL::SSLContext.new
+      end
+
       if @port.nil?
         if @ssl
           @port = DEFAULT_SSL_PORT
@@ -92,7 +96,7 @@ module PahoMqtt
       @ssl ||= true
       @ssl_context = SSLHelper.config_ssl_context(cert_path, key_path, ca_path)
     end
-    
+
     def connect(host=@host, port=@port, keep_alive=@keep_alive, persistent=@persistent, blocking=@blocking)
       @persistent = persistent
       @blocking = blocking
@@ -102,7 +106,7 @@ module PahoMqtt
       @connection_state_mutex.synchronize {
         @connection_state = MQTT_CS_NEW
       }
-      @mqtt_thread.kill unless @mqtt_thread.nil? 
+      @mqtt_thread.kill unless @mqtt_thread.nil?
       init_connection
       @connection_helper.send_connect(session_params)
       begin
@@ -249,7 +253,7 @@ module PahoMqtt
     def remove_topic_callback(topic)
       @handler.clear_topic_callback(topic)
     end
-    
+
     def on_connack(&block)
       @handler.on_connack = block if block_given?
       @handler.on_connack

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -31,7 +31,7 @@ describe PahoMqtt::Client do
         :client_id => "my_client1234",
         :username => 'Foo Bar',
         :password => 'barfoo',
-        :ssl => true,
+        :ssl => false,
         :will_topic => "my_will_topic",
         :will_payload => "Bye Bye",
         :will_qos => 1,
@@ -48,7 +48,7 @@ describe PahoMqtt::Client do
       expect(client.client_id).to eq("my_client1234") 
       expect(client.username).to eq('Foo Bar')
       expect(client.password).to eq('barfoo')
-      expect(client.ssl).to be true
+      expect(client.ssl).to be false
       expect(client.will_topic).to eq("my_will_topic")
       expect(client.will_payload).to eq("Bye Bye")    
       expect(client.will_qos).to eq(1)
@@ -56,6 +56,20 @@ describe PahoMqtt::Client do
       expect(client.keep_alive).to eq(20)
       expect(client.ack_timeout).to eq(3)
       expect(client.on_message.is_a?(Proc)).to be true
+      expect(client.ssl_context).to be nil
+    end
+
+    context "when ssl option is set to true" do
+      it "assigns ssl option" do
+        client = PahoMqtt::Client.new(ssl: true)
+        expect(client.ssl).to be true
+      end
+
+      it "creates new ssl context" do
+        allow(OpenSSL::SSL::SSLContext).to receive(:new).and_return(:new_ssl_context)
+        client = PahoMqtt::Client.new(ssl: true)
+        expect(client.ssl_context).to eq(:new_ssl_context)
+      end
     end
   end
   


### PR DESCRIPTION
When only ssl is set as true but no ssl context given, it must works
simply as every other ssl connection and verify remote server ssl
sertificate.