### PR TITLE
Fix global reference to logger in subscriber and publisher classes

### DIFF
--- a/lib/paho_mqtt/publisher.rb
+++ b/lib/paho_mqtt/publisher.rb
@@ -61,7 +61,7 @@ module PahoMqtt
       when 2
         send_pubrec(packet_id)
       else
-        @logger.error("The packet QoS value is invalid in publish.") if logger?
+        PahoMqtt.logger.error("The packet QoS value is invalid in publish.") if PahoMqtt.logger?
         raise PacketException
       end
       MQTT_ERR_SUCCESS

--- a/lib/paho_mqtt/subscriber.rb
+++ b/lib/paho_mqtt/subscriber.rb
@@ -61,12 +61,12 @@ module PahoMqtt
             adjust_qos.delete(t)
           else
 
-            @logger.error("The QoS value is invalid in subscribe.") if PahoMqtt.logger?
+            PahoMqtt.logger.error("The QoS value is invalid in subscribe.") if PahoMqtt.logger?
             raise PacketException
           end
         end
       else
-        @logger.error("The packet id is invalid, already used.") if PahoMqtt.logger?
+        PahoMqtt.logger.error("The packet id is invalid, already used.") if PahoMqtt.logger?
         raise PacketException
       end
       @subscribed_mutex.synchronize do
@@ -83,7 +83,7 @@ module PahoMqtt
       if to_unsub.length == 1
         to_unsub = to_unsub.first[:packet].topics
       else
-        @logger.error("The packet id is invalid, already used.") if PahoMqtt.logger?
+        PahoMqtt.logger.error("The packet id is invalid, already used.") if PahoMqtt.logger?
         raise PacketException
       end
 


### PR DESCRIPTION
That code generate exception when logger is enabled:
An unexpected error occurred! {:error=>#<NoMethodError: undefined method `error' for nil:NilClass>, :backtrace=>["/Users/casmeiron/Developer/tools/logstash-6.2.4/vendor/bundle/jruby/2.3.0/gems/paho-mqtt-1.0.7/lib/paho_mqtt/subscriber.rb:69:in `add_subscription'"