### PR TITLE
V 1.0.9

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,15 +111,17 @@ client = PahoMqtt::Client.new({host: "iot.eclispe.org", port: 1883, ssl: false})
 The client has many accessors which help to configure the client depending on user's need. The different accessors could be splited in four roles, connection setup, last will setup, time-out setup and callback setup.
 Connection setup:
 ```
-* host          : The endpoint where the client would try to connect (defaut "")
-* port          : The port on the remote host where the socket would try to connect (default 1883)
-* mqtt_version  : The version of MQTT protocol used to communication (default 3.1.1)
-* clean_session : If set to false, ask the message broker to try to restore the previous session (default true)
-* persistent    : Keep the client connected even after keep alive timer run out, automatically try to reconnect on failure (default false)
-* client_id     : The identifier of the client (default nil)
-* username      : The username if the server require authentication (default nil)
-* password      : The password of the user if authentication required (default nil)
-* ssl           : Requiring the encryption for the communication (default false)
+* host            : The endpoint where the client would try to connect (defaut "")
+* port            : The port on the remote host where the socket would try to connect (default 1883)
+* mqtt_version    : The version of MQTT protocol used to communication (default 3.1.1)
+* clean_session   : If set to false, ask the message broker to try to restore the previous session (default true)
+* persistent      : Keep the client connected even after keep alive timer run out, automatically try to reconnect on failure (default false)
+* reconnect_limit : If persistent mode is enabled, the maximum reconnect attempt (default 3)
+* reconnect_delay : If persistent mode is enabled, the delay between to reconnection attempt in second (default 5)
+* client_id       : The identifier of the client (default nil)
+* username        : The username if the server require authentication (default nil)
+* password        : The password of the user if authentication required (default nil)
+* ssl             : Requiring the encryption for the communication (default false)
 ```
 
 Last Will:
@@ -186,7 +188,6 @@ client.connect("test.mosquitto.org", 8884)
 ### Persistence
 The client holds a keep_alive timer is the reference time that the connection should be held. The timer is reset every time a new valid packet is received from the message broker. The persistence flag, when set to True, enables the client to be more independent from the keep_alive timer. Just before the keep_alive run out, the client sends a ping request to tell to the message broker that the connection should be kept. The persistent mode also enables the client to automatically reconnect to the message broker after an unexpected failure.  
 When the client's persistence flag is set to False, it just simply disconnects when the keep_alive timer runs out.  
-
 ```ruby
 ### This will connect to the message broker, keep connected and automatically reconnect on failure
 client.connect('iot.eclipse.org', 1883, client.keep_alive, true, client.blocking)
@@ -194,6 +195,7 @@ client.connect('iot.eclipse.org', 1883, client.keep_alive, true, client.blocking
 ### This only connect to the message broker, disconnect after keep_alive or on failure
 client.connect('iot.eclipse.org', 1883, client.keep_alive, false, client.blocking)
 ```
+The client has two attributes `@reconnect_limit` and `@reconnect_delay` which configure the reconnection process. `@reconnection_limit` is the maximum reconnection attempt that a client could try and `@reconnection_delay` is the delay that the client waits between two reconnection attempt. Setting the `@reconnect_limit` to -1 would run the reconnection process forever. 
 
 ### Foreground and Daemon
 The client could be connected to the message broker using the main thread in foreground or as a daemon in a separate thread. The default mode is daemon mode, the daemon would run in the background the read/write operation as well as the control of the timers. If the client is connected using the main thread, all control operations are left to the user, using the different control loops. There are four different loop roles is detailed in the next part.

--- a/lib/paho-mqtt.rb
+++ b/lib/paho-mqtt.rb
@@ -27,8 +27,6 @@ module PahoMqtt
   DEFAULT_PORT          = 1883
   SELECT_TIMEOUT        = 0
   LOOP_TEMPO            = 0.005
-  RECONNECT_RETRY_TIME  = 3
-  RECONNECT_RETRY_TEMPO = 5
 
   # MAX size of queue
   MAX_READ    = 10

--- a/lib/paho-mqtt.rb
+++ b/lib/paho-mqtt.rb
@@ -29,12 +29,14 @@ module PahoMqtt
   LOOP_TEMPO            = 0.005
 
   # MAX size of queue
-  MAX_READ    = 10
-  MAX_PUBACK  = 20
-  MAX_PUBREC  = 20
-  MAX_PUBREL  = 20
-  MAX_PUBCOMP = 20
-  MAX_WRITING = MAX_PUBACK + MAX_PUBREC + MAX_PUBREL  + MAX_PUBCOMP
+  MAX_SUBACK   = 10
+  MAX_UNSUBACK = 10
+  MAX_READ     = 50
+  MAX_PUBACK   = 100
+  MAX_PUBREC   = 100
+  MAX_PUBREL   = 100
+  MAX_PUBCOMP  = 100
+  MAX_WRITING  = MAX_PUBACK + MAX_PUBREC + MAX_PUBREL  + MAX_PUBCOMP
 
   # Connection states values
   MQTT_CS_NEW        = 0

--- a/lib/paho_mqtt/client.rb
+++ b/lib/paho_mqtt/client.rb
@@ -206,7 +206,7 @@ module PahoMqtt
           end
         end
         unless connected?
-          PahoMqtt.logger.error("Reconnection attempt counter is over. (#{RECONNECT_RETRY_TIME} times)") if PahoMqtt.logger?
+          PahoMqtt.logger.error("Reconnection attempt counter is over. (#{@reconnect_limit} times)") if PahoMqtt.logger?
           disconnect(false)
         end
       end
@@ -384,7 +384,7 @@ module PahoMqtt
         @publisher.config_all_message_queue
       end
       @handler.config_pubsub(@publisher, @subscriber)
-      @sender.flush_waiting_packet(true)
+      @sender.flush_waiting_packet(false)
     end
 
     def init_connection

--- a/lib/paho_mqtt/client.rb
+++ b/lib/paho_mqtt/client.rb
@@ -221,19 +221,12 @@ module PahoMqtt
     end
 
     def publish(topic, payload="", retain=false, qos=0)
-      begin
-        if topic == "" || !topic.is_a?(String)
-          PahoMqtt.logger.error("Publish topics is invalid, not a string or empty.") if PahoMqtt.logger?
-          raise ArgumentError
-        end
-        id = next_packet_id
-        @publisher.send_publish(topic, payload, retain, qos, id)
-        MQTT_ERR_SUCCESS
-      rescue FullQueuePubackException
-        PahoMqtt.logger.error('PUBACK queue is full, could not send with qos=!') if PahoMqtt.logger?
-      rescue FullQueuePubrecException
-        PahoMqtt.logger.error('PUBREC queue is full, could not send with qos=2') if PahoMqtt.logger?
+      if topic == "" || !topic.is_a?(String)
+        PahoMqtt.logger.error("Publish topics is invalid, not a string or empty.") if PahoMqtt.logger?
+        raise ArgumentError
       end
+      id = next_packet_id
+      @publisher.send_publish(topic, payload, retain, qos, id)
     end
 
     def subscribe(*topics)
@@ -248,8 +241,6 @@ module PahoMqtt
         disconnect(false)
         raise ProtocolViolation
       end
-    rescue FullQueueSubackException
-      PahoMqtt.logger.error('SUBACK queue is full, could not send subscribe') if PahoMqtt.logger?
     end
 
     def unsubscribe(*topics)
@@ -264,8 +255,6 @@ module PahoMqtt
         disconnect(false)
         raise ProtocolViolation
       end
-    rescue FullQueueUnsubackException
-      PahoMqtt.logger.error('UNSUBACK queue is full, could not send unbsubscribe') if PahoMqtt.logger?
     end
 
     def ping_host

--- a/lib/paho_mqtt/connection_helper.rb
+++ b/lib/paho_mqtt/connection_helper.rb
@@ -44,7 +44,7 @@ module PahoMqtt
         sleep 0.0001
       end
       unless is_connected?
-        PahoMqtt.logger.warn("Connection failed. Couldn't recieve a Connack packet from: #{@host}, socket is \"#{@socket}\".") if PahoMqtt.logger?
+        PahoMqtt.logger.warn("Connection failed. Couldn't recieve a Connack packet from: #{@host}.") if PahoMqtt.logger?
         raise Exception.new("Connection failed. Check log for more details.") unless reconnection
       end
       @cs

--- a/lib/paho_mqtt/exception.rb
+++ b/lib/paho_mqtt/exception.rb
@@ -40,4 +40,22 @@ module PahoMqtt
 
   class LowVersionException < Exception
   end
+
+  class FullQueuePubackException < Exception
+  end
+
+  class FullQueuePubrecException < Exception
+  end
+
+  class FullQueuePubrelException < Exception
+  end
+
+  class FullQueuePubcompException < Exception
+  end
+
+  class FullQueueSubackException < Exception
+  end
+
+  class FullQueueUnsubackException < Exception
+  end
 end

--- a/lib/paho_mqtt/exception.rb
+++ b/lib/paho_mqtt/exception.rb
@@ -40,22 +40,4 @@ module PahoMqtt
 
   class LowVersionException < Exception
   end
-
-  class FullQueuePubackException < Exception
-  end
-
-  class FullQueuePubrecException < Exception
-  end
-
-  class FullQueuePubrelException < Exception
-  end
-
-  class FullQueuePubcompException < Exception
-  end
-
-  class FullQueueSubackException < Exception
-  end
-
-  class FullQueueUnsubackException < Exception
-  end
 end

--- a/lib/paho_mqtt/handler.rb
+++ b/lib/paho_mqtt/handler.rb
@@ -85,7 +85,7 @@ module PahoMqtt
         PahoMqtt.logger.debug(packet.return_msg) if PahoMqtt.logger?
         handle_connack_accepted(packet.session_present)
       else
-        PahoMqtt.logger.warm(packet.return_msg)
+        PahoMqtt.logger.warm(packet.return_msg) if PahoMqtt.logger?
         MQTT_CS_DISCONNECTED
       end
       @on_connack.call(packet) unless @on_connack.nil?

--- a/lib/paho_mqtt/handler.rb
+++ b/lib/paho_mqtt/handler.rb
@@ -140,16 +140,12 @@ module PahoMqtt
     end
 
     def handle_publish(packet)
-      begin
         id = packet.id
         qos = packet.qos
         if @publisher.do_publish(qos, id) == MQTT_ERR_SUCCESS
           @on_message.call(packet) unless @on_message.nil?
           check_callback(packet)
         end
-      rescue FullQueuePubrelException
-        PahoMqtt.logger.error('PUBREL queue is full, could not acknowledge qos=2') if PahoMqtt.logger?
-      end
     end
 
     def handle_puback(packet)
@@ -174,13 +170,9 @@ module PahoMqtt
     end
 
     def handle_pubcomp(packet)
-      begin
-        id = packet.id
+      id = packet.id
       if @publisher.do_pubcomp(id) == MQTT_ERR_SUCCESS
         @on_pubcomp.call(packet) unless @on_pubcomp.nil?
-      end
-      rescue FullQueuePubcompcException
-        PahoMqtt.logger.error('PUBCOMP queue is full, could not acknowledge qos=2') if PahoMqtt.logger?
       end
     end
 

--- a/lib/paho_mqtt/publisher.rb
+++ b/lib/paho_mqtt/publisher.rb
@@ -39,17 +39,19 @@ module PahoMqtt
         :retain  => retain,
         :qos     => qos
       )
-      @sender.append_to_writing(packet)
       case qos
       when 1
         @puback_mutex.synchronize do
+          raise FullQueuePubackException if @waiting_puback.length >= MAX_PUBACK
           @waiting_puback.push(:id => new_id, :packet => packet, :timestamp => Time.now)
         end
       when 2
         @pubrec_mutex.synchronize do
+          raise FullQueuePubrecException if @waiting_pubrec.length >= MAX_PUBREC
           @waiting_pubrec.push(:id => new_id, :packet => packet, :timestamp => Time.now)
         end
       end
+      @sender.append_to_writing(packet)
       MQTT_ERR_SUCCESS
     end
 
@@ -86,10 +88,11 @@ module PahoMqtt
       packet = PahoMqtt::Packet::Pubrec.new(
         :id => packet_id
       )
-      @sender.append_to_writing(packet)
       @pubrel_mutex.synchronize do
+        raise FullQueuePubrelException if @waiting_pubrel.length >= MAX_PUBREL
         @waiting_pubrel.push(:id => packet_id , :packet => packet, :timestamp => Time.now)
       end
+      @sender.append_to_writing(packet)
       MQTT_ERR_SUCCESS
     end
 
@@ -105,10 +108,11 @@ module PahoMqtt
       packet = PahoMqtt::Packet::Pubrel.new(
         :id => packet_id
       )
-      @sender.append_to_writing(packet)
       @pubcomp_mutex.synchronize do
+        raise FullQueuePubcompException if @waiting_pubrel.length >= MAX_PUBCOMP
         @waiting_pubcomp.push(:id => packet_id, :packet => packet, :timestamp => Time.now)
       end
+      @sender.append_to_writing(packet)
       MQTT_ERR_SUCCESS
     end
 
@@ -136,30 +140,25 @@ module PahoMqtt
     end
 
     def config_all_message_queue
-      config_message_queue(@waiting_puback, @puback_mutex, MAX_PUBACK)
-      config_message_queue(@waiting_pubrec, @pubrec_mutex, MAX_PUBREC)
-      config_message_queue(@waiting_pubrel, @pubrel_mutex, MAX_PUBREL)
-      config_message_queue(@waiting_pubcomp, @pubcomp_mutex, MAX_PUBCOMP)
+      config_message_queue(@waiting_puback, @puback_mutex)
+      config_message_queue(@waiting_pubrec, @pubrec_mutex)
+      config_message_queue(@waiting_pubrel, @pubrel_mutex)
+      config_message_queue(@waiting_pubcomp, @pubcomp_mutex)
     end
 
-    def config_message_queue(queue, mutex, max_packet)
+    def config_message_queue(queue, mutex)
       mutex.synchronize do
-        cnt = 0
         queue.each do |pck|
-          pck[:packet].dup ||= true
-          if cnt <= max_packet
-            @sender.append_to_writing(pck[:packet])
-            cnt += 1
-          end
+          pck[:timestamp] = Time.now
         end
       end
     end
 
     def check_waiting_publisher
-      @sender.check_ack_alive(@waiting_puback, @puback_mutex, MAX_PUBACK)
-      @sender.check_ack_alive(@waiting_pubrec, @pubrec_mutex, MAX_PUBREC)
-      @sender.check_ack_alive(@waiting_pubrel, @pubrel_mutex, MAX_PUBREL)
-      @sender.check_ack_alive(@waiting_pubcomp, @pubcomp_mutex, MAX_PUBCOMP)
+      @sender.check_ack_alive(@waiting_puback, @puback_mutex)
+      @sender.check_ack_alive(@waiting_pubrec, @pubrec_mutex)
+      @sender.check_ack_alive(@waiting_pubrel, @pubrel_mutex)
+      @sender.check_ack_alive(@waiting_pubcomp, @pubcomp_mutex)
     end
 
     def flush_publisher

--- a/lib/paho_mqtt/subscriber.rb
+++ b/lib/paho_mqtt/subscriber.rb
@@ -41,7 +41,10 @@ module PahoMqtt
           @subscribed_topics = []
         end
         @suback_mutex.synchronize do
-          raise FullQueueSubackException if @waiting_suback.length >= MAX_SUBACK
+          if @waiting_suback.length >= MAX_SUBACK
+            PahoMqtt.logger.error('SUBACK queue is full, could not send subscribe') if PahoMqtt.logger?
+            return MQTT_ERR_FAILURE
+          end
           @waiting_suback.push(:id => new_id, :packet => packet, :timestamp => Time.now)
         end
         @sender.send_packet(packet)
@@ -103,7 +106,10 @@ module PahoMqtt
         )
         @sender.append_to_writing(packet)
         @suback_mutex.synchronize do
-          raise FullQueueSubackException if @waiting_suback.length >= MAX_SUBACK
+          if @waiting_suback.length >= MAX_SUBACK
+            PahoMqtt.logger.error('SUBACK queue is full, could not send subscribe') if PahoMqtt.logger?
+            return MQTT_ERR_FAILURE
+          end
           @waiting_suback.push(:id => new_id, :packet => packet, :timestamp => Time.now)
         end
         MQTT_ERR_SUCCESS
@@ -121,7 +127,10 @@ module PahoMqtt
 
         @sender.append_to_writing(packet)
         @unsuback_mutex.synchronize do
-          raise FullQueueUnsubackException if @waiting_suback.length >= MAX_UNSUBACK
+          if @waiting_suback.length >= MAX_UNSUBACK
+            PahoMqtt.logger.error('UNSUBACK queue is full, could not send unbsubscribe') if PahoMqtt.logger?
+            return MQTT_ERR_FAIL
+          end
           @waiting_unsuback.push(:id => new_id, :packet => packet, :timestamp => Time.now)
         end
         MQTT_ERR_SUCCESS

--- a/lib/paho_mqtt/subscriber.rb
+++ b/lib/paho_mqtt/subscriber.rb
@@ -60,7 +60,6 @@ module PahoMqtt
           elsif max_qos[0] == 128
             adjust_qos.delete(t)
           else
-
             PahoMqtt.logger.error("The QoS value is invalid in subscribe.") if PahoMqtt.logger?
             raise PacketException.new('Invalid suback QoS value')
           end

--- a/lib/paho_mqtt/version.rb
+++ b/lib/paho_mqtt/version.rb
@@ -1,3 +1,3 @@
 module PahoMqtt
-  VERSION = "1.0.8"
+  VERSION = "1.0.9"
 end


### PR DESCRIPTION
The version 1.0.9 is correcting some bug/misuse related with reconnection process.
- The previous reconnection constant RECONNECT_RETRY_TIME  and RECONNECT_RETRY_TEMPO are removed and a client accessors are used instead (`@reconnect_limit` and `@reconnect_delay`).
 - A bug that send twice the buffered packets during offline mode has been fix. 
- The queue/buffer size that store no-acknowledge packet when offline has been increased.
