### PR TITLE
V 1.0.10

### DIFF
--- a/lib/paho-mqtt.rb
+++ b/lib/paho-mqtt.rb
@@ -30,11 +30,11 @@ module PahoMqtt
   # MAX size of queue
   MAX_SUBACK   = 10
   MAX_UNSUBACK = 10
-  MAX_READ     = 1000
-  MAX_PUBACK   = 1000
-  MAX_PUBREC   = 1000
-  MAX_PUBREL   = 1000
-  MAX_PUBCOMP  = 1000
+  MAX_READ     = 100
+  MAX_PUBACK   = 100
+  MAX_PUBREC   = 100
+  MAX_PUBREL   = 100
+  MAX_PUBCOMP  = 100
   MAX_WRITING  = 1000
 
   # Connection states values

--- a/lib/paho-mqtt.rb
+++ b/lib/paho-mqtt.rb
@@ -25,17 +25,17 @@ module PahoMqtt
   # Default connection setup
   DEFAULT_SSL_PORT      = 8883
   DEFAULT_PORT          = 1883
-  SELECT_TIMEOUT        = 0.005
+  SELECT_TIMEOUT        = 0.002
 
   # MAX size of queue
   MAX_SUBACK   = 10
   MAX_UNSUBACK = 10
-  MAX_READ     = 50
-  MAX_PUBACK   = 100
-  MAX_PUBREC   = 100
-  MAX_PUBREL   = 100
-  MAX_PUBCOMP  = 100
-  MAX_WRITING  = MAX_PUBACK + MAX_PUBREC + MAX_PUBREL  + MAX_PUBCOMP
+  MAX_READ     = 1000
+  MAX_PUBACK   = 1000
+  MAX_PUBREC   = 1000
+  MAX_PUBREL   = 1000
+  MAX_PUBCOMP  = 1000
+  MAX_WRITING  = 1000
 
   # Connection states values
   MQTT_CS_NEW        = 0

--- a/lib/paho-mqtt.rb
+++ b/lib/paho-mqtt.rb
@@ -25,8 +25,7 @@ module PahoMqtt
   # Default connection setup
   DEFAULT_SSL_PORT      = 8883
   DEFAULT_PORT          = 1883
-  SELECT_TIMEOUT        = 0
-  LOOP_TEMPO            = 0.005
+  SELECT_TIMEOUT        = 0.005
 
   # MAX size of queue
   MAX_SUBACK   = 10

--- a/lib/paho_mqtt/client.rb
+++ b/lib/paho_mqtt/client.rb
@@ -163,15 +163,15 @@ module PahoMqtt
     end
 
     def loop_read(max_packet=MAX_READ)
-      max_packet.times do
-        begin
+      begin
+        max_packet.times do
           @handler.receive_packet
-        rescue ReadingException
-          if check_persistence
-            reconnect
-          else
-            raise ReadingException
-          end
+        end
+      rescue ReadingException
+        if check_persistence
+          reconnect
+        else
+          raise ReadingException
         end
       end
     end

--- a/lib/paho_mqtt/client.rb
+++ b/lib/paho_mqtt/client.rb
@@ -237,7 +237,6 @@ module PahoMqtt
         MQTT_ERR_SUCCESS
       rescue ProtocolViolation
         PahoMqtt.logger.error("Subscribe topics need one topic or a list of topics.") if PahoMqtt.logger?
-        disconnect(false)
         raise ProtocolViolation
       end
     end
@@ -251,7 +250,6 @@ module PahoMqtt
         MQTT_ERR_SUCCESS
       rescue ProtocolViolation
         PahoMqtt.logger.error("Unsubscribe need at least one topic.") if PahoMqtt.logger?
-        disconnect(false)
         raise ProtocolViolation
       end
     end

--- a/lib/paho_mqtt/client.rb
+++ b/lib/paho_mqtt/client.rb
@@ -180,7 +180,6 @@ module PahoMqtt
       loop_read
       loop_write
       loop_misc
-      sleep LOOP_TEMPO
     end
 
     def loop_misc

--- a/lib/paho_mqtt/connection_helper.rb
+++ b/lib/paho_mqtt/connection_helper.rb
@@ -144,22 +144,16 @@ module PahoMqtt
       MQTT_ERR_SUCCESS
     end
 
-    def send_pingreq
-      packet = PahoMqtt::Packet::Pingreq.new
-      @sender.send_packet(packet)
-      MQTT_ERR_SUCCESS
-    end
-
     def check_keep_alive(persistent, last_ping_resp, keep_alive)
       now = Time.now
       timeout_req = (@sender.last_ping_req + (keep_alive * 0.7).ceil)
       if timeout_req <= now && persistent
         PahoMqtt.logger.debug("Checking if server is still alive...") if PahoMqtt.logger?
-        send_pingreq
+        @sender.send_pingreq
       end
       timeout_resp = last_ping_resp + (keep_alive * 1.1).ceil
       if timeout_resp <= now
-        PahoMqtt.logger.debug("No activity period over timeout, disconnecting from #{@host}.") if PahoMqtt.logger?
+        PahoMqtt.logger.debug("No activity is over timeout, disconnecting from #{@host}.") if PahoMqtt.logger?
         @cs = MQTT_CS_DISCONNECT
       end
       @cs

--- a/lib/paho_mqtt/connection_helper.rb
+++ b/lib/paho_mqtt/connection_helper.rb
@@ -41,7 +41,6 @@ module PahoMqtt
       connect_timeout = Time.now + @ack_timeout
       while (Time.now <= connect_timeout) && !is_connected? do
         @cs = @handler.receive_packet
-        sleep 0.0001
       end
       unless is_connected?
         PahoMqtt.logger.warn("Connection failed. Couldn't recieve a Connack packet from: #{@host}.") if PahoMqtt.logger?

--- a/lib/paho_mqtt/exception.rb
+++ b/lib/paho_mqtt/exception.rb
@@ -40,4 +40,10 @@ module PahoMqtt
 
   class LowVersionException < Exception
   end
+
+  class FullWritingException < Exception
+  end
+
+  class FullQueueException < Exception
+  end
 end

--- a/lib/paho_mqtt/handler.rb
+++ b/lib/paho_mqtt/handler.rb
@@ -86,7 +86,7 @@ module PahoMqtt
         handle_connack_accepted(packet.session_present)
       else
         PahoMqtt.logger.warm(packet.return_msg) if PahoMqtt.logger?
-        MQTT_CS_DISCONNECTED
+        MQTT_CS_DISCONNECT
       end
       @on_connack.call(packet) unless @on_connack.nil?
       MQTT_CS_CONNECTED

--- a/lib/paho_mqtt/handler.rb
+++ b/lib/paho_mqtt/handler.rb
@@ -36,7 +36,7 @@ module PahoMqtt
     end
 
     def receive_packet
-      result = IO.select([@socket], [], [], SELECT_TIMEOUT) unless @socket.nil? || @socket.closed?
+      result = IO.select([@socket], nil, nil, SELECT_TIMEOUT) unless @socket.nil? || @socket.closed?
       unless result.nil?
         packet = PahoMqtt::Packet::Base.read(@socket)
         unless packet.nil?

--- a/lib/paho_mqtt/packet/base.rb
+++ b/lib/paho_mqtt/packet/base.rb
@@ -66,7 +66,7 @@ module PahoMqtt
           packet.instance_variable_set('@body_length', body_length)
 
           # Read in the packet body
-          packet.parse_body(socket.read(body_length))
+          packet.parse_body(socket.read_nonblock(body_length))
         end
         packet
       end
@@ -303,7 +303,7 @@ module PahoMqtt
 
       # Read and unpack a single byte from a socket
       def self.read_byte(socket)
-        byte = socket.read(1)
+        byte = socket.read_nonblock(1)
         unless byte.nil?
           byte.unpack('C').first
         else

--- a/lib/paho_mqtt/packet/base.rb
+++ b/lib/paho_mqtt/packet/base.rb
@@ -66,7 +66,7 @@ module PahoMqtt
           packet.instance_variable_set('@body_length', body_length)
 
           # Read in the packet body
-          packet.parse_body(socket.read_nonblock(body_length))
+          packet.parse_body(socket.read(body_length))
         end
         packet
       end
@@ -303,7 +303,7 @@ module PahoMqtt
 
       # Read and unpack a single byte from a socket
       def self.read_byte(socket)
-        byte = socket.read_nonblock(1)
+        byte = socket.read(1)
         unless byte.nil?
           byte.unpack('C').first
         else

--- a/lib/paho_mqtt/publisher.rb
+++ b/lib/paho_mqtt/publisher.rb
@@ -41,23 +41,27 @@ module PahoMqtt
       )
       case qos
       when 1
-        @puback_mutex.synchronize do
-          if @waiting_puback.length >= MAX_PUBACK
-            PahoMqtt.logger.error('PUBACK queue is full, could not send with qos=1') if PahoMqtt.logger?
-            return MQTT_ERR_FAIL
-          end
-          @waiting_puback.push(:id => new_id, :packet => packet, :timestamp => Time.now)
-        end
+        push_queue(@waiting_puback, @puback_mutex, MAX_PUBACK, packet, new_id)
       when 2
-        @pubrec_mutex.synchronize do
-          if @waiting_pubrec.length >= MAX_PUBREC
-            PahoMqtt.logger.error('PUBREC queue is full, could not send with qos=2') if PahoMqtt.logger?
-            return MQTT_ERR_FAIL
-          end
-          @waiting_pubrec.push(:id => new_id, :packet => packet, :timestamp => Time.now)
-        end
+        push_queue(@waiting_pubrec, @pubrec_mutex, MAX_PUBREC, packet, new_id)
       end
       @sender.append_to_writing(packet)
+      MQTT_ERR_SUCCESS
+    end
+
+    def push_queue(waiting_queue, queue_mutex, max_packet, packet, new_id)
+      begin
+        if waiting_queue.length >= max_packet
+          raise FullQueueException
+        end
+        queue_mutex.synchronize do
+          waiting_queue.push(:id => new_id, :packet => packet, :timestamp => Time.now)
+        end
+      rescue FullQueueException
+        PahoMqtt.logger.error("#{packet.type_name} queue is full") if PahoMqtt.logger?
+        sleep SELECT_TIMEOUT
+        retry
+      end
       MQTT_ERR_SUCCESS
     end
 
@@ -94,14 +98,7 @@ module PahoMqtt
       packet = PahoMqtt::Packet::Pubrec.new(
         :id => packet_id
       )
-      @pubrel_mutex.synchronize do
-        if @waiting_pubrel.length >= MAX_PUBREL
-          PahoMqtt.logger.error('PUBREL queue is full, could not acknowledge qos=2') if PahoMqtt.logger?
-          return MQTT_ERR_FAIL
-        end
-        @waiting_pubrel.push(:id => packet_id , :packet => packet, :timestamp => Time.now)
-      end
-      @sender.append_to_writing(packet)
+      push_queue(@waiting_pubrel, @pubrel_mutex, MAX_PUBREL, packet, packet_id)
       MQTT_ERR_SUCCESS
     end
 
@@ -117,15 +114,7 @@ module PahoMqtt
       packet = PahoMqtt::Packet::Pubrel.new(
         :id => packet_id
       )
-      @pubcomp_mutex.synchronize do
-        if @waiting_pubcomp.length >= MAX_PUBCOMP
-          PahoMqtt.logger.error('PUBCOMP queue is full, could not acknowledge qos=2') if PahoMqtt.logger?
-          return MQTT_ERR_FAIL
-        end
-        @waiting_pubcomp.push(:id => packet_id, :packet => packet, :timestamp => Time.now)
-      end
-      @sender.append_to_writing(packet)
-      MQTT_ERR_SUCCESS
+      push_queue(@waiting_pubcomp, @pubcomp_mutex, MAX_PUBCOMP, packet, packet_id)
     end
 
     def do_pubrel(packet_id)

--- a/lib/paho_mqtt/sender.rb
+++ b/lib/paho_mqtt/sender.rb
@@ -40,12 +40,25 @@ module PahoMqtt
     rescue IO::WaitWritable
       IO.select(nil, [@socket], nil, SELECT_TIMEOUT)
       retry
+    end
 
+    def send_pingreq
+      send_packet(PahoMqtt::Packet::Pingreq.new)
     end
 
     def append_to_writing(packet)
-      @writing_mutex.synchronize do
-        @writing_queue.push(packet) unless @writing_queue.length >= MAX_WRITING
+      begin
+        if @writing_queue.length <= MAX_WRITING
+          @writing_mutex.synchronize do
+            @writing_queue.push(packet)
+          end
+        else
+          PahoMqtt.logger.error('Writing queue is full slowing down') if PahoMqtt.logger?
+          raise FullWritingException
+        end
+      rescue FullWritingException
+        sleep SELECT_TIMEOUT
+        retry
       end
       MQTT_ERR_SUCCESS
     end
@@ -72,10 +85,6 @@ module PahoMqtt
       else
         @writing_queue = []
       end
-    end
-
-    def send_pingreq
-      append_to_writing(PahoMqtt::Packet::Pingreq.new)
     end
 
     def check_ack_alive(queue, mutex)

--- a/lib/paho_mqtt/subscriber.rb
+++ b/lib/paho_mqtt/subscriber.rb
@@ -124,7 +124,6 @@ module PahoMqtt
           :id     => new_id,
           :topics => topics
         )
-
         @sender.append_to_writing(packet)
         @unsuback_mutex.synchronize do
           if @waiting_suback.length >= MAX_UNSUBACK

--- a/lib/paho_mqtt/version.rb
+++ b/lib/paho_mqtt/version.rb
@@ -1,3 +1,3 @@
 module PahoMqtt
-  VERSION = "1.0.9"
+  VERSION = "1.0.10"
 end

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -132,7 +132,7 @@ describe PahoMqtt::Client do
       client.connect(client.host, client.port)
       expect(client.connection_state).to eq(PahoMqtt::MQTT_CS_CONNECTED)
       client.keep_alive = 0 # Make the client disconnect
-      sleep 0.001
+      sleep 1
       expect(client.connection_state).to eq(PahoMqtt::MQTT_CS_DISCONNECT)
       client.keep_alive = 15
       sleep client.ack_timeout

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -131,8 +131,8 @@ describe PahoMqtt::Client do
       client.ack_timeout = 2
       client.connect(client.host, client.port)
       expect(client.connection_state).to eq(PahoMqtt::MQTT_CS_CONNECTED)
-      client.keep_alive = 0 # Make the client disconnect
-      sleep 1
+      client.keep_alive = 1 # Make the client disconnect
+      sleep 3
       expect(client.connection_state).to eq(PahoMqtt::MQTT_CS_DISCONNECT)
       client.keep_alive = 15
       sleep client.ack_timeout


### PR DESCRIPTION
- The message buffering for sending process has been changed. Previously, the packet to be sent were buffered, waiting to be sent in background process. When the buffer was full, arriving packet were simply drop. The new version handle the full buffer event in a different way, trying to push packet on full buffer would run a short delay (2 ms) before retrying to push the packet. This approach might slow down the sending process when the client is congested, and it assert all packet are sent properly.

- The ping bugs have been fixed

- The CPU usage of client has been reduced.