### PR TITLE
V 1.0.11

### DIFF
--- a/lib/paho-mqtt.rb
+++ b/lib/paho-mqtt.rb
@@ -22,6 +22,8 @@ module PahoMqtt
   extend self
   attr_accessor :logger
 
+  MAX_PACKET_ID = 65535
+
   # Default connection setup
   DEFAULT_SSL_PORT      = 8883
   DEFAULT_PORT          = 1883
@@ -30,12 +32,12 @@ module PahoMqtt
   # MAX size of queue
   MAX_SUBACK   = 10
   MAX_UNSUBACK = 10
-  MAX_READ     = 100
   MAX_PUBACK   = 100
   MAX_PUBREC   = 100
   MAX_PUBREL   = 100
+  MAX_PUBLISH  = 1000
   MAX_PUBCOMP  = 100
-  MAX_WRITING  = 1000
+  MAX_QUEUE    = MAX_PUBACK + MAX_PUBREC + MAX_PUBREL + MAX_PUBCOMP
 
   # Connection states values
   MQTT_CS_NEW        = 0

--- a/lib/paho_mqtt/client.rb
+++ b/lib/paho_mqtt/client.rb
@@ -165,7 +165,8 @@ module PahoMqtt
     def loop_read(max_packet=MAX_READ)
       begin
         max_packet.times do
-          @handler.receive_packet
+          result = @handler.receive_packet
+          break if result.nil?
         end
       rescue ReadingException
         if check_persistence
@@ -188,6 +189,7 @@ module PahoMqtt
       end
       @publisher.check_waiting_publisher
       @subscriber.check_waiting_subscriber
+      sleep SELECT_TIMEOUT
     end
 
     def reconnect

--- a/lib/paho_mqtt/client.rb
+++ b/lib/paho_mqtt/client.rb
@@ -150,9 +150,9 @@ module PahoMqtt
       Thread.current == @reconnect_thread
     end
 
-    def loop_write(max_packet=MAX_WRITING)
+    def loop_write
       begin
-        @sender.writing_loop(max_packet)
+        @sender.writing_loop
       rescue WritingException
         if check_persistence
           reconnect
@@ -162,9 +162,9 @@ module PahoMqtt
       end
     end
 
-    def loop_read(max_packet=MAX_READ)
+    def loop_read
       begin
-        max_packet.times do
+        MAX_QUEUE.times do
           result = @handler.receive_packet
           break if result.nil?
         end
@@ -353,7 +353,8 @@ module PahoMqtt
 
     def next_packet_id
       @id_mutex.synchronize do
-        @last_packet_id = (@last_packet_id || 0).next
+        @last_packet_id = 0 if @last_packet_id >= MAX_PACKET_ID
+        @last_packet_id = @last_packet_id.next
       end
     end
 

--- a/lib/paho_mqtt/handler.rb
+++ b/lib/paho_mqtt/handler.rb
@@ -42,13 +42,14 @@ module PahoMqtt
         unless packet.nil?
           if packet.is_a?(PahoMqtt::Packet::Connack)
             @last_ping_resp = Time.now
-            handle_connack(packet)
+            return handle_connack(packet)
           else
             handle_packet(packet)
             @last_ping_resp = Time.now
           end
         end
       end
+      return result
     end
 
     def handle_packet(packet)

--- a/lib/paho_mqtt/handler.rb
+++ b/lib/paho_mqtt/handler.rb
@@ -141,12 +141,12 @@ module PahoMqtt
     end
 
     def handle_publish(packet)
-        id = packet.id
-        qos = packet.qos
-        if @publisher.do_publish(qos, id) == MQTT_ERR_SUCCESS
-          @on_message.call(packet) unless @on_message.nil?
-          check_callback(packet)
-        end
+      id = packet.id
+      qos = packet.qos
+      if @publisher.do_publish(qos, id) == MQTT_ERR_SUCCESS
+        @on_message.call(packet) unless @on_message.nil?
+        check_callback(packet)
+      end
     end
 
     def handle_puback(packet)
@@ -255,7 +255,7 @@ module PahoMqtt
         type.to_s.split('::').last.downcase
       else
         PahoMqtt.logger.error("Received an unexpeceted packet: #{packet}.") if PahoMqtt.logger?
-         raise PacketException.new('Invalid packet type id')
+        raise PacketException.new('Invalid packet type id')
       end
     end
 

--- a/lib/paho_mqtt/publisher.rb
+++ b/lib/paho_mqtt/publisher.rb
@@ -45,7 +45,6 @@ module PahoMqtt
       when 2
         push_queue(@waiting_pubrec, @pubrec_mutex, MAX_PUBREC, packet, new_id)
       end
-      @sender.append_to_writing(packet)
       MQTT_ERR_SUCCESS
     end
 
@@ -57,6 +56,7 @@ module PahoMqtt
         queue_mutex.synchronize do
           waiting_queue.push(:id => new_id, :packet => packet, :timestamp => Time.now)
         end
+        @sender.append_to_writing(packet)
       rescue FullQueueException
         PahoMqtt.logger.error("#{packet.type_name} queue is full") if PahoMqtt.logger?
         sleep SELECT_TIMEOUT

--- a/lib/paho_mqtt/publisher.rb
+++ b/lib/paho_mqtt/publisher.rb
@@ -45,6 +45,7 @@ module PahoMqtt
       when 2
         push_queue(@waiting_pubrec, @pubrec_mutex, MAX_PUBREC, packet, new_id)
       end
+      @sender.append_to_writing(packet)
       MQTT_ERR_SUCCESS
     end
 
@@ -56,7 +57,6 @@ module PahoMqtt
         queue_mutex.synchronize do
           waiting_queue.push(:id => new_id, :packet => packet, :timestamp => Time.now)
         end
-        @sender.append_to_writing(packet)
       rescue FullQueueException
         PahoMqtt.logger.error("#{packet.type_name} queue is full") if PahoMqtt.logger?
         sleep SELECT_TIMEOUT
@@ -99,6 +99,7 @@ module PahoMqtt
         :id => packet_id
       )
       push_queue(@waiting_pubrel, @pubrel_mutex, MAX_PUBREL, packet, packet_id)
+      @sender.append_to_writing(packet)
       MQTT_ERR_SUCCESS
     end
 
@@ -107,7 +108,6 @@ module PahoMqtt
         @waiting_pubrec.delete_if { |pck| pck[:id] == packet_id }
       end
       send_pubrel(packet_id)
-      MQTT_ERR_SUCCESS
     end
 
     def send_pubrel(packet_id)
@@ -115,6 +115,8 @@ module PahoMqtt
         :id => packet_id
       )
       push_queue(@waiting_pubcomp, @pubcomp_mutex, MAX_PUBCOMP, packet, packet_id)
+      @sender.append_to_writing(packet)
+      MQTT_ERR_SUCCESS
     end
 
     def do_pubrel(packet_id)
@@ -122,7 +124,6 @@ module PahoMqtt
         @waiting_pubrel.delete_if { |pck| pck[:id] == packet_id }
       end
       send_pubcomp(packet_id)
-      MQTT_ERR_SUCCESS
     end
 
     def send_pubcomp(packet_id)

--- a/lib/paho_mqtt/sender.rb
+++ b/lib/paho_mqtt/sender.rb
@@ -18,11 +18,13 @@ module PahoMqtt
     attr_accessor :last_ping_req
 
     def initialize(ack_timeout)
-      @socket        = nil
-      @writing_queue = []
-      @writing_mutex = Mutex.new
-      @last_ping_req = -1
-      @ack_timeout   = ack_timeout
+      @socket          = nil
+      @writing_queue   = []
+      @publish_queue   = []
+      @publish_mutex   = Mutex.new
+      @writing_mutex   = Mutex.new
+      @last_ping_req   = -1
+      @ack_timeout     = ack_timeout
     end
 
     def socket=(socket)
@@ -46,15 +48,24 @@ module PahoMqtt
       send_packet(PahoMqtt::Packet::Pingreq.new)
     end
 
+    def prepare_sending(queue, mutex, max_packet, packet)
+      if queue.length < max_packet
+        mutex.synchronize do
+          queue.push(packet)
+        end
+      else
+        PahoMqtt.logger.error('Writing queue is full, slowing down') if PahoMqtt.logger?
+        raise FullWritingException
+      end
+    end
+
     def append_to_writing(packet)
       begin
-        if @writing_queue.length <= MAX_WRITING
-          @writing_mutex.synchronize do
-            @writing_queue.push(packet)
-          end
+        case packet
+        when packet.is_a?(PahoMqtt::Packet::Publish)
+          prepare_sending(@publish_queue, @publish_mutex, MAX_PUBLISH, packet)
         else
-          PahoMqtt.logger.error('Writing queue is full slowing down') if PahoMqtt.logger?
-          raise FullWritingException
+          prepare_sending(@writing_queue, @writing_mutex, MAX_QUEUE, packet)
         end
       rescue FullWritingException
         sleep SELECT_TIMEOUT
@@ -63,13 +74,19 @@ module PahoMqtt
       MQTT_ERR_SUCCESS
     end
 
-    def writing_loop(max_packet)
+    def writing_loop
       @writing_mutex.synchronize do
-        cnt = 0
-        while !@writing_queue.empty? && cnt < max_packet do
+        MAX_QUEUE.times do
+          break if @writing_queue.empty?
           packet = @writing_queue.shift
           send_packet(packet)
-          cnt += 1
+        end
+      end
+      @publish_mutex.synchronize do
+        MAX_PUBLISH.times do
+          break if @publish_queue.empty?
+          packet = @publish_queue.shift
+          send_packet(packet)
         end
       end
       MQTT_ERR_SUCCESS

--- a/lib/paho_mqtt/version.rb
+++ b/lib/paho_mqtt/version.rb
@@ -1,3 +1,3 @@
 module PahoMqtt
-  VERSION = "1.0.10"
+  VERSION = "1.0.11"
 end

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -292,6 +292,7 @@ describe PahoMqtt::Client do
       expect(filter).to be false
       expect(message).to be false
       client.subscribe(["/My_all_topic/topic1", 1])
+      sleep 1
       client.publish("/My_all_topic/topic1", "Hello World", false, 0)
       while !message && !filter do
         sleep 0.0001


### PR DESCRIPTION
The previous version included a bug when qos=2. The acknowledgment packet were not send properly. 
The version 1.0.11 should fix this bug. It also correct a limit that would block the client when the packet id read 65536 (2 bytes). The packet id would be reset to 0, if the max value is reach.
Some part have been refactored to increase the client performance.

I hope everybody could enjoy this new version.

