### PR TITLE
Allow any logger

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,5 +8,8 @@
 /spec/reports/
 /tmp/
 
+.idea/
+.rubocop.yml
+
 *.gem
 *.log

--- a/lib/paho-mqtt.rb
+++ b/lib/paho-mqtt.rb
@@ -99,12 +99,16 @@ module PahoMqtt
 
   Thread.abort_on_exception = true
 
-  def logger=(logger_path)
-    file           = File.open(logger_path, "a+")
-    file.sync      = true
-    log_file       = Logger.new(file)
-    log_file.level = Logger::DEBUG
-    @logger        = log_file
+  def logger=(logger_instance)
+    if logger_instance.is_a? String
+      file           = File.open(logger_instance, 'a+')
+      file.sync      = true
+      log_file       = Logger.new(file)
+      log_file.level = Logger::DEBUG
+      @logger        = log_file
+    else
+      @logger        = logger_instance
+    end
   end
 
   def logger


### PR DESCRIPTION
Hello, 

I think that It should be possible to give an instance of any logger we want.
I had to change the code to use the `Rails` logger.

Example:

```ruby
PahoMqtt.logger = Rails.logger
```

I also add some files to `gitignore`.
